### PR TITLE
Fix invalid API call error code bug

### DIFF
--- a/api/src/app.ts
+++ b/api/src/app.ts
@@ -44,7 +44,7 @@ class App {
 
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     this.app.use((req, res, next) => {
-      res.send(getErrorResponse(404, 'Invalid API Call'));
+      res.status(404).send(getErrorResponse(404, 'Invalid API Call'));
     });
   }
 


### PR DESCRIPTION
Previously, invalid API calls would return status code `200` when it should return `404`