### PR TITLE
Update API endpoint for all questions to support pagination

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,11 @@ These environment variables are used by both the API and database images.
 
 Retrieves all questions in the database.
 
+**Parameters**
+
+- `limit` - The max number of questions in response (Optional)
+- `offset` - The offset for the first question in response (Optional)
+
 **Response**
 
 - `200` - Success.

--- a/api/src/database/question.database.ts
+++ b/api/src/database/question.database.ts
@@ -10,8 +10,8 @@ export class QuestionService {
    * Retrieves all questions in the database.
    * @returns - A promise to queried document.
    */
-  public findAll(): Promise<IQuestion[]> {
-    return question.find({}).select(['-description']).exec();
+  public findAll(limit: number, offset: number): Promise<IQuestion[]> {
+    return question.find({}, null, {limit: limit, skip: offset}).select(['-description']).exec();
   }
 
   /**

--- a/api/src/routes/route.get.ts
+++ b/api/src/routes/route.get.ts
@@ -17,7 +17,9 @@ export class GetRoute extends Routes {
 
     private _findAll = async (req: Request, res: Response) => {
         try {
-            const question = await this._questionService.findAll();
+            const limit : number = Number(req.query.limit as string);
+            const offset : number = Number(req.query.offset as string);
+            const question = await this._questionService.findAll(limit, offset);
             res.status(200).send(this._getStandardResponse('success', question, null));
         } catch (e) {
             if (e instanceof Error) {


### PR DESCRIPTION
Changes:
- Endpoint supports pagination
- e.g.> [GET] `/question-service/questions?limit=10&offset=10` returns questions 11 to 20
