### PR TITLE
Feature/pagination

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,8 @@ Retrieves all questions in the database.
 
 **Parameters**
 
+- `complexity` - The complexity of the question (Optional)
+- `categories` - The categories of the question (Optional) - Can be multiple
 - `limit` - The max number of questions in response (Optional)
 - `offset` - The offset for the first question in response (Optional)
 
@@ -167,7 +169,7 @@ Retrieves a random question by matching params.
 **Parameters**
 
 - `complexity` - The complexity of the question (Required)
-- `categories[]` - The categories of the question (Optional)
+- `categories` - The categories of the question (Optional) - Can be multiple
 
 **Response**
 

--- a/api/src/interface/question.interface.ts
+++ b/api/src/interface/question.interface.ts
@@ -19,3 +19,8 @@ export interface IFilter {
   categories: Array<string>;
   complexity: string;
 }
+
+export interface IPagination {
+  limit: number;
+  skip: number;
+}

--- a/api/src/routes/route.get.ts
+++ b/api/src/routes/route.get.ts
@@ -2,10 +2,10 @@
  * @file Handles get request endpoints.
  * @author Irving de Boer
  */
-import {Routes} from "./routes";
-import {QuestionService} from "../database/question.database";
-import {Request, Response} from 'express';
-import {IFilter} from "../interface/question.interface";
+import { Routes } from './routes';
+import { QuestionService } from '../database/question.database';
+import { Request, Response } from 'express';
+import { IFilter, IPagination } from '../interface/question.interface';
 
 export class GetRoute extends Routes {
     constructor(questionService: QuestionService) {
@@ -23,7 +23,22 @@ export class GetRoute extends Routes {
         try {
             const limit : number = Number(req.query.limit as string);
             const offset : number = Number(req.query.offset as string);
-            const question = await this._questionService.findAll(limit, offset);
+
+            const complexity: string = req.query.complexity as string;
+            let categories: Array<string> = req.query
+              .categories as Array<string>;
+
+            const page : IPagination = {
+                limit: limit,
+                skip: offset,
+            }
+
+            const filter : IFilter = {
+                complexity: complexity,
+                categories: categories,
+            };
+
+            const question = await this._questionService.findAll(page, filter);
             res.status(200).send(this._getStandardResponse('success', question, null));
         } catch (e) {
             if (e instanceof Error) {
@@ -61,7 +76,7 @@ export class GetRoute extends Routes {
                 return;
             }
 
-            const filter: IFilter = {
+            const filter = {
                 complexity: complexity,
                 categories: categories,
             };

--- a/api/src/tests/get_all_questions.test.ts
+++ b/api/src/tests/get_all_questions.test.ts
@@ -11,15 +11,30 @@ describe('Testing API endpoints for retrieving all questions', () => {
 
     describe('GET /question-service/questions', () => {
         describe('Successful request', () => {
-            it('Should return status code 200 and a list of questions in database', async () => {
-                jest.spyOn(QuestionService.prototype, 'findAll')
-                    // @ts-ignore
-                    .mockReturnValueOnce(Promise.resolve(mockData));
-                const {statusCode} = await supertest(newApp).get('/question-service/questions');
-                expect(QuestionService.prototype.findAll).toHaveBeenCalled();
-                expect(statusCode).toBe(200);
+            describe('Request with no filter', () => {
+                it('Should return status code 200 and a list of questions in database', async () => {
+                    jest.spyOn(QuestionService.prototype, 'findAll')
+                        // @ts-ignore
+                        .mockReturnValueOnce(Promise.resolve(mockData));
+                    const {statusCode} = await supertest(newApp).get('/question-service/questions');
+                    expect(QuestionService.prototype.findAll).toHaveBeenCalled();
+                    expect(statusCode).toBe(200);
+                });
+            });
+
+            describe('Request with filter', () => {
+                it('Should return status code 200 and a list of questions in database', async () => {
+                    jest.spyOn(QuestionService.prototype, 'findAll')
+                        // @ts-ignore
+                        .mockReturnValueOnce(Promise.resolve(mockData[0]));
+                    const {statusCode} = await supertest(newApp)
+                        .get('/question-service/questions?complexity=Easy&categories[]=Algorithms&categories[]=Strings');
+                    expect(QuestionService.prototype.findAll).toHaveBeenCalled();
+                    expect(statusCode).toBe(200);
+                });
             });
         });
+
 
         describe('Unsuccessful request', () => {
            it('Should return status code 500 and an error message', async () => {


### PR DESCRIPTION
Update endpoint to get all questions with filtering

Previous Behaviour: No filtering
New Behaviour: > [GET] `/question-service/questions?complexity=Easy&categories=Algorithms&categories=Strings&` -> Retrieves all questions with matching filters
