### PR TITLE
Update question service to include editor template

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,7 +148,14 @@ Retrieves a question by its ID.
           "title": "Example Question",
           "description": "Placeholder Description",
           "complexity": "Easy",
-          "categories": ["Arrays"]   
+          "categories": ["Arrays"],
+          "template": [
+            {
+              "language": "C++",
+              "langSlug": "cpp",
+              "code": "class Solution {\npublic:\n    int lengthOfLongestSubstring(string s) {\n        \n    }\n};"  
+            }
+          ]   
         },
         "message": null
       }

--- a/api/src/database/question.database.ts
+++ b/api/src/database/question.database.ts
@@ -65,7 +65,7 @@ export class QuestionService {
     }
 
     console.log({ ...filter });
-    return question.find({...filter, deleted: false}).select('-deleted -deletedAt').exec();
+    return question.find({...filter, deleted: false}).select('_id title').exec();
   }
 
   /**

--- a/api/src/database/question.database.ts
+++ b/api/src/database/question.database.ts
@@ -22,7 +22,7 @@ export class QuestionService {
       if (filter.categories == undefined) {
         return question.find({ deleted: false }, null, {
           ...page
-        }).select('-description -deleted -deletedAt').exec();
+        }).select('-description -deleted -deletedAt -template').exec();
       }
     }
 

--- a/api/src/interface/question.interface.ts
+++ b/api/src/interface/question.interface.ts
@@ -11,10 +11,16 @@ export interface IQuestion extends Document {
   description: string;
   categories: Array<string>;
   complexity: string;
+  template: [
+    {
+      language: string;
+      langSlug: string;
+      code: string;
+    }
+  ];
   deleted: boolean;
   deletedAt: Date;
 }
-
 export interface IFilter {
   categories: Array<string>;
   complexity: string;

--- a/api/src/models/question.model.ts
+++ b/api/src/models/question.model.ts
@@ -11,8 +11,15 @@ const questionModel = new Schema({
   description: { type: String, required: [true, 'Field is required'] },
   categories: { type: Array<string>, required: [true, 'Field is required'] },
   complexity: { type: String, required: [true, 'Field is required'] },
-  deleted: {type: Boolean, default: false, required: [true, 'Field is required']},
-  deletedAt: {type: Date, default: null},
+  template: [
+    {
+      language: { type: String, required: false },
+      langSlug: { type: String, required: false},
+      code: { type: String, required: false }
+    }
+  ],
+  deleted: { type: Boolean, default: false, required: [true, 'Field is required'] },
+  deletedAt: { type: Date, default: null }
 });
 
 export const question = model<IQuestion>('Question', questionModel);


### PR DESCRIPTION
Changes: Question data now includes a field `templates` which is an array of objects of the following fields

- `language`
- `languageSlug`
- `code`
