### PR TITLE
Update endpoint for matching service to return only id and title

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,10 @@ Retrieves a question by its ID.
       - description
       - complexity
       - categories
+      - template
+        - language
+        - langSlug
+        - code
     - Example Response Body
       ```json
       {
@@ -184,19 +188,13 @@ Retrieves a random question by matching params.
     - Returns question with matching filters as JSON Object with the following fields:
         - id
         - title
-        - description
-        - complexity
-        - categories
     - Example Response Body
       ```json
       {
         "status": "success",
         "data": {
           "id": "123",
-          "title": "Example Question",
-          "description": "Placeholder Description",
-          "complexity": "Easy",
-          "categories": ["Arrays"]   
+          "title": "Example Question"
         },
         "message": null
       }

--- a/api/src/constants/question-service-api.constants.ts
+++ b/api/src/constants/question-service-api.constants.ts
@@ -7,5 +7,5 @@ import * as dotenv from 'dotenv';
 dotenv.config();
 
 export const PORT = process.env.EXPRESS_DOCKER_PORT;
-export const MONGO_URI = process.env.MONGO_URI_DEV!
+export const MONGO_URI = process.env.MONGO_URI_LOCAL!
 

--- a/api/src/database/question.database.ts
+++ b/api/src/database/question.database.ts
@@ -65,7 +65,8 @@ export class QuestionService {
     }
 
     console.log({ ...filter });
-    return question.find({...filter, deleted: false}).select('_id title').exec();
+    return question.find({ ...filter, deleted: false }).select(`-deleted -deletedAt -template -description
+     -categories -complexity`).exec();
   }
 
   /**


### PR DESCRIPTION
New behaviour: Endpoint to fetch question by params returns the following fields

- `id`
- `title`